### PR TITLE
add the option to include menubar applications on macOS (close #35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ $ nuke Music Slack Notion
 
 _Ignores Music, Slack, and Notion_
 
+### ➕ Include menubar apps
+
+By default, Nuke will only close and list applications running from the Dock. If you want to also include the ones running only in the menubar, you can add the following to your config:
+
+```yaml
+includeMenubarApps: true
+```
+
+This is a macOS only option.
+
 ### 🚀 Update Checks
 
 By default nuke checks if there is an update every time you run it. If you want to turn it off add the following to your config:

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 	s.Start()
 	switch operatingSystem {
 	case "darwin":
-		macApps, err := desktop.MacOSApplications()
+		macApps, err := desktop.MacOSApplications(configContents.IncludeMenubarApps)
 		if err != nil {
 			statuser.Error("Failed to get macos applications", err, 1)
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,8 +11,9 @@ var path = "/.config/nuke/"
 
 // Config for nuke
 type Conf struct {
-	IgnoreUpdates bool     `yaml:"ignoredUpdates"`
-	IgnoredApps   []string `yaml:"ignoredApps"`
+	IgnoreUpdates      bool     `yaml:"ignoredUpdates"`
+	IgnoredApps        []string `yaml:"ignoredApps"`
+	IncludeMenubarApps bool     `yaml:"includeMenubarApps"`
 }
 
 // Check if the config exists


### PR DESCRIPTION
## Description

Add the option to include menubar applications on macOS

## Steps

- [X] My change requires a change to the documentation
- [X] I have updated the accessible documentation according
- [X] I have read the **CONTRIBUTING.md** file
- [X] There is no duplicate open or closed pull request for this fix/addition/issue resolution.

## Original Issue

This PR resolves #35